### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,4 +1,6 @@
 name: Update CO2 Emissions Data
+permissions:
+  contents: write
 
 on:
   # Run monthly on the 1st at midnight


### PR DESCRIPTION
Potential fix for [https://github.com/kuasar-mknd/visualdon-projet/security/code-scanning/1](https://github.com/kuasar-mknd/visualdon-projet/security/code-scanning/1)

**General Fix:**  
Add a `permissions` block to the workflow at either the workflow root or job level, set to the minimum needed. For this workflow, write access to repository contents (`contents: write`) is sufficient, since it checks out code and pushes updates, but it doesn’t need broader write permissions (e.g., to issues, pull requests, actions, etc.).

**Detailed Fix:**  
Insert the following block right beneath the `name: ...` field (after line 1):

```yaml
permissions:
  contents: write
```

Alternatively, you could add this block at the job level (after line 12, before or after `runs-on`), but root-level is clearer, and all jobs here have the same requirement. No additional methods, imports, or variable changes are necessary—this is a YAML/CI configuration-only fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
