### PR TITLE
🧭 DocOps: docs + GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,20 +34,20 @@ jobs:
       - name: Lint
         if: ${{ hashFiles('package.json') != '' }}
         run: |
-            if npm run | grep -q "lint"; then
+            if jq -e '.scripts["lint"]' package.json > /dev/null; then
               pnpm run lint
             fi
 
       - name: Build
         if: ${{ hashFiles('package.json') != '' }}
         run: |
-            if npm run | grep -q "build"; then
+            if jq -e '.scripts["build"]' package.json > /dev/null; then
               pnpm run build
             fi
 
       - name: Test
         if: ${{ hashFiles('package.json') != '' }}
         run: |
-            if npm run | grep -q "test"; then
+            if jq -e '.scripts["test"]' package.json > /dev/null; then
               pnpm run test
             fi

--- a/.jules/docops-history.md
+++ b/.jules/docops-history.md
@@ -9,3 +9,4 @@
 | 2026-03-22 | Docs + Workflows | README.md, docs/*, .github/workflows/*, .env.example | Updated docs to reflect Frontend stack (Vite/React/D3). Added CI, CodeQL, Dependency Review workflows. |
 | 2026-03-22 | Docs + Automation | README.md, docs/AI.md, docs/API.md, docs/ENV.md, .github/workflows/*, verification/verify-integrity.js | Standardized AI/ENV/API docs for frontend; added CI, CodeQL, Dependency Review; added integrity check script. |
 | 2026-03-22 | DocOps Refinement | README.md, docs/ENV.md, docs/AI.md, docs/ARCHITECTURE.md | Refined ENV docs (Cloudflare token), added AI standards/schemas, clarified Architecture, polished README. Verified with lint/test. |
+| 2026-03-22 | DocOps Update | README.md, docs/API.md, .github/workflows/ci.yml | Updated canonical URL to co2.kuasar.xyz; hardened CI script detection with jq. |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🌍 Global CO₂ Emissions Visualization
 
-[![Deployment Status](https://img.shields.io/badge/Cloudflare%20Pages-Deployed-orange?logo=cloudflare)](https://visualdon-projet.pages.dev)
+[![Deployment Status](https://img.shields.io/badge/Cloudflare%20Pages-Deployed-orange?logo=cloudflare)](https://co2.kuasar.xyz)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Data Source](https://zenodo.org/badge/DOI/10.5281/zenodo.7215364.svg)](https://doi.org/10.5281/zenodo.7215364)
 [![React](https://img.shields.io/badge/React-19.2.3-61DAFB?logo=react)](https://react.dev)
@@ -67,7 +67,7 @@ This project uses authoritative emissions data from the [Global Carbon Budget](h
 The application exposes its data via a static API. You can retrieve the current dataset manifest using curl:
 
 ```bash
-curl -s https://visualdon-projet.pages.dev/data/manifest.json
+curl -s https://co2.kuasar.xyz/data/manifest.json
 ```
 
 For full documentation on available data endpoints and schemas, see [docs/API.md](docs/API.md).
@@ -194,7 +194,7 @@ This visualization is based on the Global Carbon Budget dataset, which provides 
 
 ## 🔗 Links
 
-- **Live Demo**: [https://visualdon-projet.pages.dev](https://visualdon-projet.pages.dev)
+- **Live Demo**: [https://co2.kuasar.xyz](https://co2.kuasar.xyz)
 - **Report Issues**: [GitHub Issues](https://github.com/kuasar-mknd/visualdon-projet/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/kuasar-mknd/visualdon-projet/discussions)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -36,7 +36,7 @@ To support versioned data without requiring code changes, the application uses a
 You can inspect the current data manifest using curl:
 
 ```bash
-curl -s https://visualdon-projet.pages.dev/data/manifest.json | jq .
+curl -s https://co2.kuasar.xyz/data/manifest.json | jq .
 ```
 
 ## Internal Services


### PR DESCRIPTION
Updated documentation to point to the canonical domain `co2.kuasar.xyz` instead of the Cloudflare Pages subdomain. Enhanced the CI workflow to use `jq` for checking `package.json` scripts, improving robustness compared to the previous `grep` method. Updated the DocOps history file.

---
*PR created automatically by Jules for task [3028394675190437307](https://jules.google.com/task/3028394675190437307) started by @kuasar-mknd*