### PR TITLE
🧭 DocOps: docs + GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.jules/docops-history.md
+++ b/.jules/docops-history.md
@@ -9,3 +9,4 @@
 | 2026-03-22 | Docs + Workflows | README.md, docs/*, .github/workflows/*, .env.example | Updated docs to reflect Frontend stack (Vite/React/D3). Added CI, CodeQL, Dependency Review workflows. |
 | 2026-03-22 | Docs + Automation | README.md, docs/AI.md, docs/API.md, docs/ENV.md, .github/workflows/*, verification/verify-integrity.js | Standardized AI/ENV/API docs for frontend; added CI, CodeQL, Dependency Review; added integrity check script. |
 | 2026-03-22 | DocOps Refinement | README.md, docs/ENV.md, docs/AI.md, docs/ARCHITECTURE.md | Refined ENV docs (Cloudflare token), added AI standards/schemas, clarified Architecture, polished README. Verified with lint/test. |
+| 2026-03-22 | Workflows | .github/workflows/update-data.yml | Fixed invalid action versions (v6 -> v4) in update-data workflow. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,7 +1,10 @@
 # API & Data Documentation
 
 ## Overview
-This application is a **frontend-only** visualization tool. It does not communicate with a traditional backend API for its core functionality during runtime. Instead, it relies on static data files served from the `public/data` directory, managed via a manifest file.
+This application is a **frontend-only** visualization tool. It does not communicate with a traditional backend API (like Hono or Express) for its core functionality during runtime. Instead, it relies on static data files served from the `public/data` directory, managed via a manifest file.
+
+## Authentication
+As a static frontend application, there is no API authentication or authorization mechanism. All data is publicly accessible.
 
 This document describes the structure of these data files, which serve as the "API" for the application.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ The application follows a component-based architecture where each UI element is 
 - **Container/Presenter**: Some components act as containers (fetching data/state) while others are purely presentational.
 
 ### Clean Architecture Mapping
-While this is a frontend-only application, the structure loosely maps to Clean Architecture principles:
+This project is a **client-side only** React application and does not include a backend server (e.g., Hono, Express). However, the structure loosely maps to Clean Architecture principles:
 - **Domain Layer**: Implicitly defined by the data structures (emissions data) and types. `src/services/` contains domain-specific logic like country translation.
 - **Application Layer**: `src/hooks/` and `src/context/` manage the application state and business logic (e.g., filtering data by year).
 - **Infrastructure Layer**:


### PR DESCRIPTION
# DocOps Update

This PR updates the documentation and GitHub Workflows.

## Changes

### 🔧 Workflows
- **Fixed `update-data.yml`**: It was referencing non-existent `v6` versions of `actions/checkout` and `actions/setup-node`. Updated to the standard `v4`.
- **Refined `ci.yml`**: Added top-level security permissions (`contents: read`). Verified it correctly detects and runs available scripts (`lint`, `test`, `build`) using `pnpm`.

### 📚 Documentation
- **Updated `docs/ARCHITECTURE.md`**: Explicitly clarified that this is a client-side only application (React + Vite), resolving potential ambiguity regarding "backend" components.
- **Updated `docs/API.md`**: Added a section clarifying that there is no backend authentication/authorization as it serves static files.
- **Verified**: `README.md`, `docs/ENV.md`, and `docs/AI.md` were reviewed and found to be accurate for the current codebase.

## Verification
- Run `pnpm install`
- Run `pnpm run lint`
- Run `pnpm test`
- Inspect `.github/workflows/update-data.yml` to see `v4` tags.

## Note on Scope
The user prompt mentioned a "TypeScript backend (Hono + Prisma)". However, inspection of the codebase confirms this is a Frontend-only React project. The documentation and workflows have been optimized for the **actual** codebase (Frontend) rather than the persona description, to strictly adhere to the "Keep docs truthful" directive.


---
*PR created automatically by Jules for task [6021841965543041186](https://jules.google.com/task/6021841965543041186) started by @kuasar-mknd*