### PR TITLE
🎨 Palette: Interactive Semantics & Focus Polish (x5)

### DIFF
--- a/src/components/CountryChart.jsx
+++ b/src/components/CountryChart.jsx
@@ -88,10 +88,12 @@ const CountryChart = ({ countryCode, data: emissionData }) => {
     <div className="w-full h-full flex flex-col">
       {/* View Mode Toggle */}
       <div className="flex items-center gap-3 mb-4 flex-wrap">
-        <div role="group" aria-label={t('chart.selectViewMode')} className="flex gap-2">
+        <div role="radiogroup" aria-label={t('chart.selectViewMode')} className="flex gap-2">
           <button
             onClick={() => setViewMode('bubbles')}
-            aria-pressed={viewMode === 'bubbles'}
+            aria-checked={viewMode === 'bubbles'}
+            role="radio"
+            aria-controls="chart-container"
             className={`px-4 py-2 rounded-lg font-semibold transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 outline-none cursor-pointer ${
               viewMode === 'bubbles'
                 ? 'bg-blue-50 text-blue-600 border border-blue-200 shadow-sm'
@@ -102,7 +104,9 @@ const CountryChart = ({ countryCode, data: emissionData }) => {
           </button>
           <button
             onClick={() => setViewMode('lines')}
-            aria-pressed={viewMode === 'lines'}
+            aria-checked={viewMode === 'lines'}
+            role="radio"
+            aria-controls="chart-container"
             className={`px-4 py-2 rounded-lg font-semibold transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 outline-none cursor-pointer ${
               viewMode === 'lines'
                 ? 'bg-blue-50 text-blue-600 border border-blue-200 shadow-sm'
@@ -131,7 +135,7 @@ const CountryChart = ({ countryCode, data: emissionData }) => {
       </div>
       
       {/* Chart Container */}
-      <div className="flex-1 bg-transparent rounded-lg overflow-hidden relative">
+      <div id="chart-container" className="flex-1 bg-transparent rounded-lg overflow-hidden relative">
         <div ref={containerRef} className="w-full h-full absolute inset-0">
            {dimensions.width > 0 && dimensions.height > 0 && emissionData.length > 0 && (
              <Suspense fallback={<LoadingPlaceholder />}>

--- a/src/components/controls/Timeline.jsx
+++ b/src/components/controls/Timeline.jsx
@@ -43,6 +43,9 @@ const Timeline = ({ year, setYear, yearRange }) => {
           disabled={!year}
           onChange={handleYearChange}
           aria-label={t('aria.selectYear')}
+          aria-orientation="horizontal"
+          aria-valuemin={yearRange.min}
+          aria-valuemax={yearRange.max}
           aria-valuetext={`${t('aria.yearLabel')} ${localYear || yearRange.min}`}
           aria-keyshortcuts="ArrowLeft ArrowRight"
           title={`${t('aria.selectYear')} (←/→)`}

--- a/src/components/globe/GlobeLegend.jsx
+++ b/src/components/globe/GlobeLegend.jsx
@@ -20,19 +20,19 @@ const GlobeLegend = ({ maxVal, displayCategory }) => {
         <div className="absolute bottom-4 left-4 bg-white/80 backdrop-blur-sm rounded-xl border border-slate-200 p-4 text-slate-600 text-xs shadow-lg" role="region" aria-label={t('emissionsLabel')}>
              <div className="font-semibold mb-3 text-sm text-slate-700">{t('emissionsLabel')}</div>
              <div className="space-y-2" role="list">
-                 <div className="flex items-center gap-3" role="listitem">
+                 <div className="flex items-center gap-3" role="listitem" title={t('legend.low')}>
                      <div className="w-3 h-3 rounded-full" style={{background: '#3b82f6'}} aria-hidden="true"></div>
                      <span className="text-slate-600">{t('legend.low')}</span>
                  </div>
-                 <div className="flex items-center gap-3" role="listitem">
+                 <div className="flex items-center gap-3" role="listitem" title={t('legend.moderate')}>
                      <div className="w-3 h-3 rounded-full" style={{background: '#10b981'}} aria-hidden="true"></div>
                      <span className="text-slate-600">{t('legend.moderate')}</span>
                  </div>
-                 <div className="flex items-center gap-3" role="listitem">
+                 <div className="flex items-center gap-3" role="listitem" title={t('legend.medium')}>
                      <div className="w-3 h-3 rounded-full" style={{background: '#fbbf24'}} aria-hidden="true"></div>
                      <span className="text-slate-600">{t('legend.medium')}</span>
                  </div>
-                 <div className="flex items-center gap-3" role="listitem">
+                 <div className="flex items-center gap-3" role="listitem" title={`${t('legend.high')} ${formattedMax ? `(> ${formattedMax} ${unit})` : ''}`}>
                      <div className="w-3 h-3 rounded-full" style={{background: '#ef4444'}} aria-hidden="true"></div>
                      <span className="text-slate-600">
                         {t('legend.high')}
@@ -43,7 +43,7 @@ const GlobeLegend = ({ maxVal, displayCategory }) => {
                         )}
                      </span>
                  </div>
-                 <div className="flex items-center gap-3 pt-1 border-t border-slate-200 mt-1" role="listitem">
+                 <div className="flex items-center gap-3 pt-1 border-t border-slate-200 mt-1" role="listitem" title={t('noData')}>
                      <div className="w-3 h-3 rounded-full bg-slate-300" aria-hidden="true"></div>
                      <span className="text-slate-600">{t('noData')}</span>
                  </div>

--- a/src/components/layout/HeaderContent.jsx
+++ b/src/components/layout/HeaderContent.jsx
@@ -21,7 +21,8 @@ const HeaderContent = () => {
           >
               <button
                   onClick={() => language !== 'en' && toggleLanguage()}
-                  aria-pressed={language === 'en'}
+                  aria-current={language === 'en' ? 'true' : undefined}
+                  lang="en"
                   aria-label={t('aria.switchToEnglish')}
                   title="English"
                   className={`px-3 py-1.5 rounded-md text-xs font-bold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 outline-none cursor-pointer ${
@@ -34,7 +35,8 @@ const HeaderContent = () => {
               </button>
               <button
                   onClick={() => language !== 'fr' && toggleLanguage()}
-                  aria-pressed={language === 'fr'}
+                  aria-current={language === 'fr' ? 'true' : undefined}
+                  lang="fr"
                   aria-label={t('aria.switchToFrench')}
                   title="Français"
                   className={`px-3 py-1.5 rounded-md text-xs font-bold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 outline-none cursor-pointer ${

--- a/src/components/overlay/CountryDetailsOverlay.jsx
+++ b/src/components/overlay/CountryDetailsOverlay.jsx
@@ -7,6 +7,7 @@ import { sanitizeString } from '../../utils/security';
 const CountryDetailsOverlay = ({ selectedCountry, selectedCountryName, displayCountry, onClose, countryData }) => {
   const { t } = useLanguage();
 
+  const overlayRef = useRef(null);
   const closeButtonRef = useRef(null);
   const previousFocusRef = useRef(null);
 
@@ -14,8 +15,11 @@ const CountryDetailsOverlay = ({ selectedCountry, selectedCountryName, displayCo
   useEffect(() => {
     let timer;
     if (selectedCountry) {
-      // Store current focus
-      previousFocusRef.current = document.activeElement;
+      // Store current focus ONLY if we are opening (previousFocus is null)
+      // This prevents overwriting the trigger element reference during internal updates
+      if (!previousFocusRef.current) {
+         previousFocusRef.current = document.activeElement;
+      }
 
       // Move focus to close button
       // Use setTimeout to ensure visibility transition has started (removing 'invisible' class)
@@ -33,6 +37,39 @@ const CountryDetailsOverlay = ({ selectedCountry, selectedCountryName, displayCo
     return () => clearTimeout(timer);
   }, [selectedCountry]);
 
+  // Trap focus inside overlay
+  useEffect(() => {
+      if (!selectedCountry) return;
+
+      const handleTab = (e) => {
+          if (e.key === 'Tab') {
+              const focusableElements = overlayRef.current?.querySelectorAll(
+                  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+              );
+
+              if (!focusableElements || focusableElements.length === 0) return;
+
+              const firstElement = focusableElements[0];
+              const lastElement = focusableElements[focusableElements.length - 1];
+
+              if (e.shiftKey) {
+                  if (document.activeElement === firstElement) {
+                      e.preventDefault();
+                      lastElement.focus();
+                  }
+              } else {
+                  if (document.activeElement === lastElement) {
+                      e.preventDefault();
+                      firstElement.focus();
+                  }
+              }
+          }
+      };
+
+      window.addEventListener('keydown', handleTab);
+      return () => window.removeEventListener('keydown', handleTab);
+  }, [selectedCountry]);
+
   // Close overlay on Escape key press
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -47,6 +84,7 @@ const CountryDetailsOverlay = ({ selectedCountry, selectedCountryName, displayCo
 
   return (
     <div 
+      ref={overlayRef}
       role="dialog"
       aria-modal="true"
       aria-labelledby="overlay-title"


### PR DESCRIPTION
This PR implements a batch of 5 micro-UX improvements focused on accessibility and semantic correctness, as identified by the Palette agent.

**Changes:**
1.  **HeaderContent.jsx:** Replaced `aria-pressed` with `aria-current="true"` for the language switcher and added `lang` attributes (e.g., `lang="fr"`) to ensure correct pronunciation by screen readers.
2.  **CountryChart.jsx:** Updated the chart view mode toggle to use `role="radiogroup"` and `role="radio"` with `aria-checked` attributes, providing better "one of many" semantics than standard buttons. Added `aria-controls` pointing to the chart container.
3.  **CountryDetailsOverlay.jsx:** Implemented a focus trap (cycling Tab navigation) within the modal to prevent focus from leaking to the background, and improved the `previousFocusRef` logic to reliably restore focus upon closing.
4.  **Timeline.jsx:** Added standard ARIA slider attributes: `aria-orientation="horizontal"`, `aria-valuemin`, and `aria-valuemax`.
5.  **GlobeLegend.jsx:** Added `title` attributes to legend items to provide native browser tooltips on hover.

**Verification:**
-   **Automated:** Ran `pnpm lint` (clean) and `pnpm test` (passed integrity checks).
-   **Frontend:** Verified using a custom Playwright script (`verification_temp/verify_palette.py`) which confirmed the presence of all new attributes and correct role application.
-   **Visual:** Confirmed UI integrity via screenshot.

---
*PR created automatically by Jules for task [2809659581716419389](https://jules.google.com/task/2809659581716419389) started by @kuasar-mknd*