### PR TITLE
🧭 DocOps: Fix workflows and standardize on pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,20 +34,20 @@ jobs:
       - name: Lint
         if: ${{ hashFiles('package.json') != '' }}
         run: |
-            if npm run | grep -q "lint"; then
+            if pnpm run | grep -q "lint"; then
               pnpm run lint
             fi
 
       - name: Build
         if: ${{ hashFiles('package.json') != '' }}
         run: |
-            if npm run | grep -q "build"; then
+            if pnpm run | grep -q "build"; then
               pnpm run build
             fi
 
       - name: Test
         if: ${{ hashFiles('package.json') != '' }}
         run: |
-            if npm run | grep -q "test"; then
+            if pnpm run | grep -q "test"; then
               pnpm run test
             fi

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -26,7 +26,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.jules/docops-history.md
+++ b/.jules/docops-history.md
@@ -9,3 +9,4 @@
 | 2026-03-22 | Docs + Workflows | README.md, docs/*, .github/workflows/*, .env.example | Updated docs to reflect Frontend stack (Vite/React/D3). Added CI, CodeQL, Dependency Review workflows. |
 | 2026-03-22 | Docs + Automation | README.md, docs/AI.md, docs/API.md, docs/ENV.md, .github/workflows/*, verification/verify-integrity.js | Standardized AI/ENV/API docs for frontend; added CI, CodeQL, Dependency Review; added integrity check script. |
 | 2026-03-22 | DocOps Refinement | README.md, docs/ENV.md, docs/AI.md, docs/ARCHITECTURE.md | Refined ENV docs (Cloudflare token), added AI standards/schemas, clarified Architecture, polished README. Verified with lint/test. |
+| 2026-10-14 | DocOps Fixes | CONTRIBUTING.md, .github/workflows/* | Fixed invalid action versions, standardized on pnpm in docs and CI |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Unsure where to start? Look for issues labeled:
 ### Prerequisites
 
 - Node.js 20.x or higher
-- npm 10.x or higher
+- pnpm (via `npm install -g pnpm`)
 - Git
 
 ### Setup Steps
@@ -76,19 +76,20 @@ cd visualdon-projet
 git remote add upstream https://github.com/kuasar-mknd/visualdon-projet.git
 
 # Install dependencies
-npm install
+pnpm install
 
 # Start development server
-npm run dev
+pnpm run dev
 ```
 
 ### Available Scripts
 
-- `npm run dev` - Start development server with hot reload
-- `npm run build` - Build for production
-- `npm run preview` - Preview production build locally
-- `npm run lint` - Run ESLint to check code quality
-- `npm run update-data` - Fetch latest CO₂ emissions data
+- `pnpm run dev` - Start development server with hot reload
+- `pnpm run build` - Build for production
+- `pnpm run preview` - Preview production build locally
+- `pnpm run lint` - Run ESLint to check code quality
+- `pnpm run update-data` - Fetch latest CO₂ emissions data
+- `pnpm test` - Run data integrity and manifest checks
 
 ## 📏 Coding Standards
 
@@ -102,7 +103,7 @@ npm run dev
 
 ### Code Style
 
-We use ESLint to enforce code style. Run `npm run lint` before committing.
+We use ESLint to enforce code style. Run `pnpm run lint` before committing.
 
 **Key conventions:**
 
@@ -218,7 +219,13 @@ src/
 
 ## 🧪 Testing
 
-Currently, this project relies on manual testing. Contributions to add automated tests are highly welcome!
+This project uses a combination of automated checks and manual testing.
+
+**Automated Tests:**
+Run the integrity checks to verify data consistency and environment setup:
+```bash
+pnpm test
+```
 
 **Manual testing checklist:**
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ An interactive 3D globe visualization exploring global CO₂ emissions from 1750
 ### Prerequisites
 
 - Node.js 20.x or higher
-- pnpm (or npm/yarn)
+- pnpm
 
 ### Installation
 
@@ -36,7 +36,7 @@ An interactive 3D globe visualization exploring global CO₂ emissions from 1750
 git clone https://github.com/kuasar-mknd/visualdon-projet.git
 cd visualdon-projet
 
-# Install dependencies (auto-detects pnpm/npm/yarn)
+# Install dependencies
 pnpm install
 
 # Start development server


### PR DESCRIPTION
Updated documentation and GitHub workflows to fix invalid action versions and standardize on `pnpm` as the package manager.

Changes:
- **`CONTRIBUTING.md`**: Replaced `npm` with `pnpm` in all commands and instructions. Added testing section referencing `pnpm test`.
- **`README.md`**: Updated prerequisites and installation steps to strictly enforce `pnpm`.
- **`.github/workflows/update-data.yml`**: Downgraded `actions/checkout` and `actions/setup-node` from `v6` (invalid) to `v4` (stable).
- **`.github/workflows/ci.yml`**: Updated script detection logic to use `pnpm run` instead of `npm run`.
- **`.jules/docops-history.md`**: Added entry for this update.

Verification:
- Ran `pnpm lint` and `pnpm test` locally (passed).
- Verified `ci.yml` syntax.
- Confirmed `codeql.yml`, `dependency-review.yml`, and `dependabot.yml` are present in the repository (security workflows).

---
*PR created automatically by Jules for task [14481431911740509296](https://jules.google.com/task/14481431911740509296) started by @kuasar-mknd*