### PR TITLE
🧭 DocOps: docs + GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       - name: Use Node.js 20
         uses: actions/setup-node@v4

--- a/.jules/docops-history.md
+++ b/.jules/docops-history.md
@@ -9,3 +9,4 @@
 | 2026-03-22 | Docs + Workflows | README.md, docs/*, .github/workflows/*, .env.example | Updated docs to reflect Frontend stack (Vite/React/D3). Added CI, CodeQL, Dependency Review workflows. |
 | 2026-03-22 | Docs + Automation | README.md, docs/AI.md, docs/API.md, docs/ENV.md, .github/workflows/*, verification/verify-integrity.js | Standardized AI/ENV/API docs for frontend; added CI, CodeQL, Dependency Review; added integrity check script. |
 | 2026-03-22 | DocOps Refinement | README.md, docs/ENV.md, docs/AI.md, docs/ARCHITECTURE.md | Refined ENV docs (Cloudflare token), added AI standards/schemas, clarified Architecture, polished README. Verified with lint/test. |
+| 2026-03-23 | Docs + Workflows | CONTRIBUTING.md, README.md, docs/ARCHITECTURE.md, .github/workflows/ci.yml | Standardized pnpm usage, verified workflows, clarified architecture, enhanced maintenance docs. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Unsure where to start? Look for issues labeled:
 ### Prerequisites
 
 - Node.js 20.x or higher
-- npm 10.x or higher
+- pnpm 10.x or higher
 - Git
 
 ### Setup Steps
@@ -76,19 +76,19 @@ cd visualdon-projet
 git remote add upstream https://github.com/kuasar-mknd/visualdon-projet.git
 
 # Install dependencies
-npm install
+pnpm install
 
 # Start development server
-npm run dev
+pnpm run dev
 ```
 
 ### Available Scripts
 
-- `npm run dev` - Start development server with hot reload
-- `npm run build` - Build for production
-- `npm run preview` - Preview production build locally
-- `npm run lint` - Run ESLint to check code quality
-- `npm run update-data` - Fetch latest CO₂ emissions data
+- `pnpm run dev` - Start development server with hot reload
+- `pnpm run build` - Build for production
+- `pnpm run preview` - Preview production build locally
+- `pnpm run lint` - Run ESLint to check code quality
+- `pnpm run update-data` - Fetch latest CO₂ emissions data
 
 ## 📏 Coding Standards
 
@@ -102,7 +102,7 @@ npm run dev
 
 ### Code Style
 
-We use ESLint to enforce code style. Run `npm run lint` before committing.
+We use ESLint to enforce code style. Run `pnpm run lint` before committing.
 
 **Key conventions:**
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ To ensure code quality and prevent regressions, run the linter:
 pnpm lint
 ```
 
+### Continuous Integration
+The project employs GitHub Actions for automated verification:
+- **CI**: Runs tests, linting, and build checks on every push.
+- **CodeQL**: Performs static security analysis.
+- **Dependency Review**: Scans for vulnerable dependencies in Pull Requests.
+
 ## 🤝 Contributing
 
 We welcome contributions from the community! Whether you're fixing bugs, improving documentation, or proposing new features, your help is appreciated.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,8 @@
 ## Overview
 This project is a client-side Single Page Application (SPA) built with React 19 and Vite. It visualizes global CO₂ emissions data using D3.js for charts and Three.js (via React components) for 3D globe elements. The application is designed to be performant, accessible, and responsive.
 
+> **Note:** This application is **Frontend-Only** and does not currently rely on a traditional backend API or database (e.g., Hono, Prisma, Postgres) for runtime operations. Data is served as static CSV files.
+
 ## Core Technologies
 - **React 19**: UI library for building component-based user interfaces.
 - **Vite**: Next-generation frontend tooling for fast builds and hot module replacement.


### PR DESCRIPTION
This PR acts as a "DocOps" update to standardize the project documentation and CI/CD workflows.

**Changes:**
- **Documentation:**
    - `CONTRIBUTING.md`: Replaced all `npm` references with `pnpm` to match the actual package manager used (`package.json`, `pnpm-lock.yaml`).
    - `docs/ARCHITECTURE.md`: Added an explicit note in the Overview clarifying that this is a **Frontend-Only** application, preventing future confusion with backend stacks (Hono/Prisma).
    - `README.md`: Added a "Continuous Integration" section under Verification to document the existing workflows.
- **Workflows:**
    - `.github/workflows/ci.yml`: Updated `pnpm` action version from 9 to 10 to match the local environment (`v10.28.0`).

**Verification:**
- Ran `pnpm lint`, `pnpm test`, and `pnpm build` locally, all passed.
- Verified `.env.example` is correct.

**DocOps History:**
- Updated `.jules/docops-history.md`.

---
*PR created automatically by Jules for task [15405638467774907857](https://jules.google.com/task/15405638467774907857) started by @kuasar-mknd*