### PR TITLE
🎨 Palette: Semantic Switchers (x2)

### DIFF
--- a/src/components/CountryChart.jsx
+++ b/src/components/CountryChart.jsx
@@ -88,10 +88,11 @@ const CountryChart = ({ countryCode, data: emissionData }) => {
     <div className="w-full h-full flex flex-col">
       {/* View Mode Toggle */}
       <div className="flex items-center gap-3 mb-4 flex-wrap">
-        <div role="group" aria-label={t('chart.selectViewMode')} className="flex gap-2">
+        <div role="radiogroup" aria-label={t('chart.selectViewMode')} className="flex gap-2">
           <button
+            role="radio"
             onClick={() => setViewMode('bubbles')}
-            aria-pressed={viewMode === 'bubbles'}
+            aria-checked={viewMode === 'bubbles'}
             className={`px-4 py-2 rounded-lg font-semibold transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 outline-none cursor-pointer ${
               viewMode === 'bubbles'
                 ? 'bg-blue-50 text-blue-600 border border-blue-200 shadow-sm'
@@ -101,8 +102,9 @@ const CountryChart = ({ countryCode, data: emissionData }) => {
             <span aria-hidden="true" className="mr-2">🫧</span>{t('chart.bubbles')}
           </button>
           <button
+            role="radio"
             onClick={() => setViewMode('lines')}
-            aria-pressed={viewMode === 'lines'}
+            aria-checked={viewMode === 'lines'}
             className={`px-4 py-2 rounded-lg font-semibold transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 outline-none cursor-pointer ${
               viewMode === 'lines'
                 ? 'bg-blue-50 text-blue-600 border border-blue-200 shadow-sm'

--- a/src/components/layout/HeaderContent.jsx
+++ b/src/components/layout/HeaderContent.jsx
@@ -15,13 +15,14 @@ const HeaderContent = () => {
 
       <div className="flex items-center gap-4">
           <div
-            role="group"
+            role="radiogroup"
             aria-label={t('aria.toggleLanguage')}
             className="flex p-1 bg-slate-100/50 hover:bg-slate-100 border border-slate-200 rounded-lg transition-colors"
           >
               <button
+                  role="radio"
                   onClick={() => language !== 'en' && toggleLanguage()}
-                  aria-pressed={language === 'en'}
+                  aria-checked={language === 'en'}
                   aria-label={t('aria.switchToEnglish')}
                   title="English"
                   className={`px-3 py-1.5 rounded-md text-xs font-bold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 outline-none cursor-pointer ${
@@ -33,8 +34,9 @@ const HeaderContent = () => {
                   EN
               </button>
               <button
+                  role="radio"
                   onClick={() => language !== 'fr' && toggleLanguage()}
-                  aria-pressed={language === 'fr'}
+                  aria-checked={language === 'fr'}
                   aria-label={t('aria.switchToFrench')}
                   title="Français"
                   className={`px-3 py-1.5 rounded-md text-xs font-bold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 outline-none cursor-pointer ${


### PR DESCRIPTION
This PR updates the semantic roles of the Language Toggle and View Mode Toggle. Previously, they used `role="group"` with `aria-pressed`, which is technically for toggle buttons (independent on/off states). They now use `role="radiogroup"` with `role="radio"` and `aria-checked`, which correctly semantically conveys that these are mutually exclusive options (e.g., English OR French, Bubbles OR Lines). This improves the experience for screen reader users.

**Cluster:** Semantic Switchers (x2)
**Files:** `src/components/layout/HeaderContent.jsx`, `src/components/CountryChart.jsx`
**A11y:** WCAG 4.1.2 Name, Role, Value - Ensures proper role identification for exclusive selection controls.

---
*PR created automatically by Jules for task [4240058137753801617](https://jules.google.com/task/4240058137753801617) started by @kuasar-mknd*