### PR TITLE
🎨 Palette: Semantic Polish (x5)

### DIFF
--- a/src/components/CountryChart.jsx
+++ b/src/components/CountryChart.jsx
@@ -88,10 +88,11 @@ const CountryChart = ({ countryCode, data: emissionData }) => {
     <div className="w-full h-full flex flex-col">
       {/* View Mode Toggle */}
       <div className="flex items-center gap-3 mb-4 flex-wrap">
-        <div role="group" aria-label={t('chart.selectViewMode')} className="flex gap-2">
+        <div role="radiogroup" aria-label={t('chart.selectViewMode')} className="flex gap-2">
           <button
             onClick={() => setViewMode('bubbles')}
-            aria-pressed={viewMode === 'bubbles'}
+            role="radio"
+            aria-checked={viewMode === 'bubbles'}
             className={`px-4 py-2 rounded-lg font-semibold transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 outline-none cursor-pointer ${
               viewMode === 'bubbles'
                 ? 'bg-blue-50 text-blue-600 border border-blue-200 shadow-sm'
@@ -102,7 +103,8 @@ const CountryChart = ({ countryCode, data: emissionData }) => {
           </button>
           <button
             onClick={() => setViewMode('lines')}
-            aria-pressed={viewMode === 'lines'}
+            role="radio"
+            aria-checked={viewMode === 'lines'}
             className={`px-4 py-2 rounded-lg font-semibold transition-all focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 outline-none cursor-pointer ${
               viewMode === 'lines'
                 ? 'bg-blue-50 text-blue-600 border border-blue-200 shadow-sm'

--- a/src/components/Globe.jsx
+++ b/src/components/Globe.jsx
@@ -315,6 +315,7 @@ const Globe = ({ data, geoJson, category, maxVal, onCountrySelect, displayCatego
       tabIndex="0"
       aria-label={t('aria.globeDescription')}
       role="application"
+      aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight + -"
       onKeyDown={handleKeyDown}
     >
        <svg

--- a/src/components/charts/BubbleChart.jsx
+++ b/src/components/charts/BubbleChart.jsx
@@ -139,7 +139,7 @@ const BubbleChart = ({
             .transition()
             .duration(200)
             .attr("opacity", 1)
-            .attr("stroke", "#3b82f6") // Blue-500 for visible focus/active state
+            .attr("stroke", "#1e293b") // Slate-800 for high-contrast focus state
             .attr("stroke-width", 3);
 
         // Remove existing tooltips to prevent duplicates

--- a/src/components/charts/StackedAreaChart.jsx
+++ b/src/components/charts/StackedAreaChart.jsx
@@ -77,7 +77,7 @@ const StackedAreaChart = ({
     const handleInteractionStart = function(event, d) {
         select(this)
             .attr('opacity', 1)
-            .attr("stroke", "#3b82f6") // Blue focus ring
+            .attr("stroke", "#1e293b") // Slate-800 for high-contrast focus ring
             .attr("stroke-width", 2);
 
         // Highlight in legend

--- a/src/components/layout/HeaderContent.jsx
+++ b/src/components/layout/HeaderContent.jsx
@@ -15,13 +15,14 @@ const HeaderContent = () => {
 
       <div className="flex items-center gap-4">
           <div
-            role="group"
+            role="radiogroup"
             aria-label={t('aria.toggleLanguage')}
             className="flex p-1 bg-slate-100/50 hover:bg-slate-100 border border-slate-200 rounded-lg transition-colors"
           >
               <button
                   onClick={() => language !== 'en' && toggleLanguage()}
-                  aria-pressed={language === 'en'}
+                  role="radio"
+                  aria-checked={language === 'en'}
                   aria-label={t('aria.switchToEnglish')}
                   title="English"
                   className={`px-3 py-1.5 rounded-md text-xs font-bold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 outline-none cursor-pointer ${
@@ -34,7 +35,8 @@ const HeaderContent = () => {
               </button>
               <button
                   onClick={() => language !== 'fr' && toggleLanguage()}
-                  aria-pressed={language === 'fr'}
+                  role="radio"
+                  aria-checked={language === 'fr'}
                   aria-label={t('aria.switchToFrench')}
                   title="Français"
                   className={`px-3 py-1.5 rounded-md text-xs font-bold transition-all duration-200 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 outline-none cursor-pointer ${


### PR DESCRIPTION
This PR implements a batch of micro-UX and accessibility improvements ("Semantic Polish"):
1.  **Semantic Toggles:** Converted `role="group"` + `aria-pressed` patterns to `role="radiogroup"` + `role="radio"` + `aria-checked` in `HeaderContent.jsx` and `CountryChart.jsx`. This aligns better with the exclusive choice nature of these controls.
2.  **Focus Contrast:** Changed the focus/hover stroke color in `BubbleChart.jsx` and `StackedAreaChart.jsx` from Blue-500 (#3b82f6) to Slate-800 (#1e293b). This resolves low-contrast issues when focusing on blue data points.
3.  **Keyboard Discovery:** Added `aria-keyshortcuts` to the `Globe.jsx` container to expose available keyboard navigation commands (Arrows, +, -).

Verified with `pnpm lint`, `pnpm test`, and manual visual verification via Playwright screenshots.

---
*PR created automatically by Jules for task [12338156458742207686](https://jules.google.com/task/12338156458742207686) started by @kuasar-mknd*