### PR TITLE
🎨 Palette: The Focus Fixer (x3)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,7 +169,7 @@ function AppContent() {
     <div className="min-h-screen text-slate-800 p-2 md:p-4 font-sans selection:bg-blue-100 selection:text-blue-900 overflow-hidden">
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only absolute top-4 left-4 z-[100] px-4 py-2 bg-blue-600 text-white font-bold rounded-lg shadow-lg focus:outline-none focus:ring-4 focus:ring-blue-300 transition-transform"
+        className="sr-only focus:not-sr-only absolute top-4 left-4 z-[100] px-4 py-2 bg-blue-600 text-white font-bold rounded-lg shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 transition-transform"
       >
         {t('aria.skipToContent')}
       </a>

--- a/src/components/controls/PlayControls.jsx
+++ b/src/components/controls/PlayControls.jsx
@@ -47,7 +47,7 @@ const PlayControls = ({ isPlaying, setIsPlaying, category, setCategory }) => {
           value={category}
           onChange={(e) => setCategory(e.target.value)}
           aria-label={t('aria.selectCategory')}
-          className="bg-white border border-slate-200 rounded-xl px-4 py-2 focus:ring-2 focus:ring-blue-500 outline-none text-slate-700 font-medium shadow-sm cursor-pointer hover:border-blue-300 transition-colors text-sm"
+          className="bg-white border border-slate-200 rounded-xl px-4 py-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 outline-none text-slate-700 font-medium shadow-sm cursor-pointer hover:border-blue-300 transition-colors text-sm"
         >
           <option value="Total">{t('total')}</option>
           <option value="Per Capita">{t('perCapita')}</option>

--- a/src/components/globe/GlobePaths.jsx
+++ b/src/components/globe/GlobePaths.jsx
@@ -13,7 +13,7 @@ const GlobePaths = ({ geoJson, onCountrySelect, onHover, onLeave }) => {
                 key={countryId || i}
                 stroke="#0f172a"
                 strokeWidth="0.5"
-                className="country-path transition-colors duration-300 hover:opacity-80 cursor-pointer outline-none focus:outline-none focus:opacity-100 focus:stroke-white focus:stroke-[1.5px]"
+                className="country-path transition-colors duration-300 hover:opacity-80 cursor-pointer outline-none focus-visible:outline-none focus-visible:opacity-100 focus-visible:stroke-white focus-visible:stroke-[1.5px]"
                 role="button"
                 tabIndex="0"
                 aria-label={feature.properties.NAME || countryId}


### PR DESCRIPTION
🎯 **Cluster:** The Focus Fixer (Standardizing `focus` to `focus-visible`)
📄 **Files:** `src/App.jsx`, `src/components/controls/PlayControls.jsx`, `src/components/globe/GlobePaths.jsx`
♿ **A11y:** WCAG 2.4.7 Focus Visible. Ensuring keyboard users have strong, visible focus rings, without punishing mouse/touch users with persistent sticky outlines after clicking.

Batch modifications:
1. `App.jsx`: Updated the "Skip to main content" link to use `focus-visible:ring-2` instead of standard focus. (Left `focus:not-sr-only` intact so the element still becomes visible to the eye on any focus, but the ring itself relies on `focus-visible`).
2. `PlayControls.jsx`: Changed the `category` select dropdown from `focus:ring-2` to `focus-visible:ring-2 focus-visible:ring-offset-2`.
3. `GlobePaths.jsx`: Replaced the SVG specific sticky `focus` outline/stroke with `focus-visible:outline-none focus-visible:opacity-100 focus-visible:stroke-white focus-visible:stroke-[1.5px]`.

*Tests and linting passed. Headless browser visual verification confirmed successful keyboard focus ring generation.*

---
*PR created automatically by Jules for task [8121424293761583159](https://jules.google.com/task/8121424293761583159) started by @kuasar-mknd*