### PR TITLE
🎨 Palette: Accessible Focus States & Icons (x3)

### DIFF
--- a/src/components/CountryChart.jsx
+++ b/src/components/CountryChart.jsx
@@ -114,12 +114,12 @@ const CountryChart = ({ countryCode, data: emissionData }) => {
         </div>
 
         {viewMode === 'bubbles' && (
-          <label className="flex items-center gap-3 px-4 py-2 bg-white rounded-lg border border-slate-200 cursor-pointer hover:bg-slate-50 transition-colors focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-blue-500 shadow-sm">
+          <label className="flex items-center gap-3 px-4 py-2 bg-white rounded-lg border border-slate-200 cursor-pointer hover:bg-slate-50 transition-colors shadow-sm">
             <input 
               type="checkbox" 
               checked={split} 
               onChange={(e) => setSplit(e.target.checked)}
-              className="w-4 h-4 accent-blue-600 cursor-pointer outline-none"
+              className="w-4 h-4 accent-blue-600 cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
             />
             <span className="text-slate-700 font-medium">{t('chart.splitBySector')}</span>
           </label>

--- a/src/components/controls/PlayControls.jsx
+++ b/src/components/controls/PlayControls.jsx
@@ -47,7 +47,7 @@ const PlayControls = ({ isPlaying, setIsPlaying, category, setCategory }) => {
           value={category}
           onChange={(e) => setCategory(e.target.value)}
           aria-label={t('aria.selectCategory')}
-          className="bg-white border border-slate-200 rounded-xl px-4 py-2 focus:ring-2 focus:ring-blue-500 outline-none text-slate-700 font-medium shadow-sm cursor-pointer hover:border-blue-300 transition-colors text-sm"
+          className="bg-white border border-slate-200 rounded-xl px-4 py-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 outline-none text-slate-700 font-medium shadow-sm cursor-pointer hover:border-blue-300 transition-colors text-sm"
         >
           <option value="Total">{t('total')}</option>
           <option value="Per Capita">{t('perCapita')}</option>

--- a/src/components/globe/GlobeHint.jsx
+++ b/src/components/globe/GlobeHint.jsx
@@ -14,13 +14,13 @@ const GlobeHint = () => {
          {t('aria.globeControls') || "Keyboard shortcuts: Use Arrow keys to rotate the globe. Use Plus and Minus keys to zoom in and out."}
        </p>
        <div className="flex items-center gap-2 text-xs text-slate-600 font-medium bg-white/60 px-3 py-1.5 rounded-full backdrop-blur-md border border-white/50 shadow-sm cursor-help">
-         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
            <path d="M5 9l-3 3 3 3M9 5l3-3 3 3M19 9l3 3-3 3M15 19l-3 3-3-3M2 12h20M12 2v20"/>
          </svg>
          <span>{t('globe.drag')}</span>
        </div>
        <div className="flex items-center gap-2 text-xs text-slate-600 font-medium bg-white/60 px-3 py-1.5 rounded-full backdrop-blur-md border border-white/50 shadow-sm cursor-help">
-         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
            <circle cx="12" cy="12" r="10"/>
            <path d="M8 12h8"/>
            <path d="M12 8v8"/>


### PR DESCRIPTION
🎯 **Cluster:** Add missing or incorrect ARIA properties (specifically `aria-hidden`) to decorative SVGs, and fix focus visibility styles across interactive controls.

📄 **Files:** 
- `src/components/controls/PlayControls.jsx`
- `src/components/CountryChart.jsx`
- `src/components/globe/GlobeHint.jsx`

♿ **A11y:**
- Replaced basic `:focus` and `:focus-within` with `:focus-visible` to support keyboard navigation visibility without lingering outlines after mouse clicks (WCAG 2.4.7 Focus Visible).
- Added `aria-hidden="true"` to decorative SVGs in `GlobeHint.jsx` to prevent screen reader clutter (WCAG 1.1.1 Non-text Content).

---
*PR created automatically by Jules for task [6423248460257888294](https://jules.google.com/task/6423248460257888294) started by @kuasar-mknd*