### PR TITLE
🎨 Palette: Decorative SVGs Aria-Hidden (x2)

### DIFF
--- a/src/components/globe/GlobeHint.jsx
+++ b/src/components/globe/GlobeHint.jsx
@@ -14,13 +14,13 @@ const GlobeHint = () => {
          {t('aria.globeControls') || "Keyboard shortcuts: Use Arrow keys to rotate the globe. Use Plus and Minus keys to zoom in and out."}
        </p>
        <div className="flex items-center gap-2 text-xs text-slate-600 font-medium bg-white/60 px-3 py-1.5 rounded-full backdrop-blur-md border border-white/50 shadow-sm cursor-help">
-         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
            <path d="M5 9l-3 3 3 3M9 5l3-3 3 3M19 9l3 3-3 3M15 19l-3 3-3-3M2 12h20M12 2v20"/>
          </svg>
          <span>{t('globe.drag')}</span>
        </div>
        <div className="flex items-center gap-2 text-xs text-slate-600 font-medium bg-white/60 px-3 py-1.5 rounded-full backdrop-blur-md border border-white/50 shadow-sm cursor-help">
-         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
            <circle cx="12" cy="12" r="10"/>
            <path d="M8 12h8"/>
            <path d="M12 8v8"/>


### PR DESCRIPTION
🎨 **Palette: Decorative SVGs Aria-Hidden (x2)**

🎯 **Cluster:** Hidden Icons
Identified inline `<svg>` elements that serve purely decorative purposes (accompanied by descriptive text) but lack the `aria-hidden="true"` attribute, which can lead to redundant or confusing announcements by screen readers.

📄 **Files:**
- `src/components/globe/GlobeHint.jsx`

♿ **A11y:** WCAG 2.1 Non-text Content (1.1.1). Ensuring decorative images are ignored by assistive technologies.

---
*PR created automatically by Jules for task [12138877934849469536](https://jules.google.com/task/12138877934849469536) started by @kuasar-mknd*